### PR TITLE
Add configurable OIDC auth flow

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -298,14 +298,15 @@ use codex_feedback::FeedbackUploadOptions;
 use codex_git_utils::git_diff_to_remote;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_login::AuthManager;
-use codex_login::CLIENT_ID;
 use codex_login::CodexAuth;
+use codex_login::LoginAuthConfig;
 use codex_login::ServerOptions as LoginServerOptions;
 use codex_login::ShutdownHandle;
 use codex_login::auth::login_with_chatgpt_auth_tokens;
 use codex_login::complete_device_code_login;
 use codex_login::login_with_api_key;
 use codex_login::request_device_code;
+use codex_login::resolve_oidc_login_config;
 use codex_login::run_login_server;
 use codex_mcp::McpRuntimeEnvironment;
 use codex_mcp::McpServerStatusSnapshot;
@@ -1401,14 +1402,17 @@ impl CodexMessageProcessor {
             });
         }
 
+        let auth_config =
+            resolve_oidc_login_config(LoginAuthConfig::from_config_toml(config.auth.clone())).await;
         let opts = LoginServerOptions {
             open_browser: false,
             ..LoginServerOptions::new(
                 config.codex_home.to_path_buf(),
-                CLIENT_ID.to_string(),
+                auth_config.client_id.clone(),
                 config.forced_chatgpt_workspace_id.clone(),
                 config.cli_auth_credentials_store_mode,
             )
+            .with_auth_config(auth_config)
         };
         #[cfg(debug_assertions)]
         let opts = {

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -10,12 +10,13 @@
 use codex_app_server_protocol::AuthMode;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_core::config::Config;
-use codex_login::CLIENT_ID;
 use codex_login::CodexAuth;
+use codex_login::LoginAuthConfig;
 use codex_login::ServerOptions;
 use codex_login::login_with_agent_identity;
 use codex_login::login_with_api_key;
 use codex_login::logout_with_revoke;
+use codex_login::resolve_oidc_login_config;
 use codex_login::run_device_code_login;
 use codex_login::run_login_server;
 use codex_protocol::config_types::ForcedLoginMethod;
@@ -117,13 +118,16 @@ pub async fn login_with_chatgpt(
     codex_home: PathBuf,
     forced_chatgpt_workspace_id: Option<String>,
     cli_auth_credentials_store_mode: AuthCredentialsStoreMode,
+    auth_config: LoginAuthConfig,
 ) -> std::io::Result<()> {
+    let auth_config = resolve_oidc_login_config(auth_config).await;
     let opts = ServerOptions::new(
         codex_home,
-        CLIENT_ID.to_string(),
+        auth_config.client_id.clone(),
         forced_chatgpt_workspace_id,
         cli_auth_credentials_store_mode,
-    );
+    )
+    .with_auth_config(auth_config);
     let server = run_login_server(opts)?;
 
     print_login_server_start(server.actual_port, &server.auth_url);
@@ -147,6 +151,7 @@ pub async fn run_login_with_chatgpt(cli_config_overrides: CliConfigOverrides) ->
         config.codex_home.to_path_buf(),
         forced_chatgpt_workspace_id,
         config.cli_auth_credentials_store_mode,
+        LoginAuthConfig::from_config_toml(config.auth.clone()),
     )
     .await
     {
@@ -274,15 +279,21 @@ pub async fn run_login_with_device_code(
         std::process::exit(1);
     }
     let forced_chatgpt_workspace_id = config.forced_chatgpt_workspace_id.clone();
-    let mut opts = ServerOptions::new(
+    let mut auth_config = LoginAuthConfig::from_config_toml(config.auth.clone());
+    if let Some(client_id) = client_id {
+        auth_config.client_id = client_id;
+    }
+    if let Some(issuer) = issuer_base_url {
+        auth_config.issuer = issuer;
+    }
+    let auth_config = resolve_oidc_login_config(auth_config).await;
+    let opts = ServerOptions::new(
         config.codex_home.to_path_buf(),
-        client_id.unwrap_or(CLIENT_ID.to_string()),
+        auth_config.client_id.clone(),
         forced_chatgpt_workspace_id,
         config.cli_auth_credentials_store_mode,
-    );
-    if let Some(iss) = issuer_base_url {
-        opts.issuer = iss;
-    }
+    )
+    .with_auth_config(auth_config);
     match run_device_code_login(opts).await {
         Ok(()) => {
             eprintln!("{LOGIN_SUCCESS_MESSAGE}");
@@ -313,15 +324,21 @@ pub async fn run_login_with_device_code_fallback_to_browser(
     }
 
     let forced_chatgpt_workspace_id = config.forced_chatgpt_workspace_id.clone();
+    let mut auth_config = LoginAuthConfig::from_config_toml(config.auth.clone());
+    if let Some(client_id) = client_id {
+        auth_config.client_id = client_id;
+    }
+    if let Some(issuer) = issuer_base_url {
+        auth_config.issuer = issuer;
+    }
+    let auth_config = resolve_oidc_login_config(auth_config).await;
     let mut opts = ServerOptions::new(
         config.codex_home.to_path_buf(),
-        client_id.unwrap_or(CLIENT_ID.to_string()),
+        auth_config.client_id.clone(),
         forced_chatgpt_workspace_id,
         config.cli_auth_credentials_store_mode,
-    );
-    if let Some(iss) = issuer_base_url {
-        opts.issuer = iss;
-    }
+    )
+    .with_auth_config(auth_config);
     opts.open_browser = false;
 
     match run_device_code_login(opts.clone()).await {

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -10,6 +10,7 @@ use crate::profile_toml::ConfigProfile;
 use crate::types::AnalyticsConfigToml;
 use crate::types::ApprovalsReviewer;
 use crate::types::AppsConfigToml;
+use crate::types::AuthConfigToml;
 use crate::types::AuthCredentialsStoreMode;
 use crate::types::FeedbackConfigToml;
 use crate::types::History;
@@ -282,6 +283,9 @@ pub struct ConfigToml {
 
     /// Base URL override for the built-in `openai` model provider.
     pub openai_base_url: Option<String>,
+
+    /// OIDC-compatible auth server configuration used by interactive login.
+    pub auth: Option<AuthConfigToml>,
 
     /// Machine-local realtime audio device preferences used by realtime voice.
     #[serde(default)]

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -58,6 +58,35 @@ pub enum AuthCredentialsStoreMode {
     Ephemeral,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct AuthConfigToml {
+    /// OIDC issuer used for interactive browser login.
+    pub issuer: Option<String>,
+    /// Public OAuth/OIDC client identifier.
+    pub client_id: Option<String>,
+    /// Scopes requested during browser login.
+    pub scopes: Option<Vec<String>>,
+    /// Token type requested when exchanging OIDC login credentials for a router API key.
+    pub requested_token_type: Option<String>,
+    /// Resource audience requested when exchanging OIDC login credentials for a router API key.
+    pub router_audience: Option<String>,
+    /// Optional explicit endpoint overrides. When unset, endpoints are derived from the issuer or
+    /// discovered from OIDC metadata by the auth layer.
+    pub endpoints: Option<AuthEndpointConfigToml>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct AuthEndpointConfigToml {
+    /// Explicit authorization endpoint override.
+    pub authorization: Option<String>,
+    /// Explicit token endpoint override.
+    pub token: Option<String>,
+    /// Explicit revocation endpoint override.
+    pub revocation: Option<String>,
+}
+
 /// Determine where Codex should store and read MCP credentials.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -264,6 +264,43 @@
         }
       ]
     },
+    "AuthConfigToml": {
+      "additionalProperties": false,
+      "properties": {
+        "client_id": {
+          "description": "Public OAuth/OIDC client identifier.",
+          "type": "string"
+        },
+        "endpoints": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AuthEndpointConfigToml"
+            }
+          ],
+          "description": "Optional explicit endpoint overrides. When unset, endpoints are derived from the issuer or discovered from OIDC metadata by the auth layer."
+        },
+        "issuer": {
+          "description": "OIDC issuer used for interactive browser login.",
+          "type": "string"
+        },
+        "requested_token_type": {
+          "description": "Token type requested when exchanging OIDC login credentials for a router API key.",
+          "type": "string"
+        },
+        "router_audience": {
+          "description": "Resource audience requested when exchanging OIDC login credentials for a router API key.",
+          "type": "string"
+        },
+        "scopes": {
+          "description": "Scopes requested during browser login.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "AuthCredentialsStoreMode": {
       "description": "Determine where Codex should store CLI auth credentials.",
       "oneOf": [
@@ -296,6 +333,24 @@
           "type": "string"
         }
       ]
+    },
+    "AuthEndpointConfigToml": {
+      "additionalProperties": false,
+      "properties": {
+        "authorization": {
+          "description": "Explicit authorization endpoint override.",
+          "type": "string"
+        },
+        "revocation": {
+          "description": "Explicit revocation endpoint override.",
+          "type": "string"
+        },
+        "token": {
+          "description": "Explicit token endpoint override.",
+          "type": "string"
+        }
+      },
+      "type": "object"
     },
     "AutoReviewToml": {
       "properties": {
@@ -2452,6 +2507,14 @@
       ],
       "default": null,
       "description": "Machine-local realtime audio device preferences used by realtime voice."
+    },
+    "auth": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AuthConfigToml"
+        }
+      ],
+      "description": "OIDC-compatible auth server configuration used by interactive login."
     },
     "auto_review": {
       "allOf": [

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -32,6 +32,7 @@ use codex_config::loader::project_trust_key;
 use codex_config::profile_toml::ConfigProfile;
 use codex_config::sandbox_mode_requirement_for_permission_profile;
 use codex_config::types::ApprovalsReviewer;
+use codex_config::types::AuthConfigToml;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_config::types::DEFAULT_OTEL_ENVIRONMENT;
 use codex_config::types::History;
@@ -61,6 +62,7 @@ use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_login::AuthManagerConfig;
+use codex_login::LoginAuthConfig;
 use codex_mcp::McpConfig;
 use codex_memories_write::memory_root;
 use codex_model_provider_info::LEGACY_OLLAMA_CHAT_PROVIDER_ID;
@@ -618,6 +620,9 @@ pub struct Config {
     /// Base URL for requests to ChatGPT (as opposed to the OpenAI API).
     pub chatgpt_base_url: String,
 
+    /// OIDC-compatible interactive auth configuration.
+    pub auth: Option<AuthConfigToml>,
+
     /// Machine-local realtime audio device preferences used by realtime voice.
     pub realtime_audio: RealtimeAudioConfig,
 
@@ -777,6 +782,10 @@ impl AuthManagerConfig for Config {
 
     fn chatgpt_base_url(&self) -> String {
         self.chatgpt_base_url.clone()
+    }
+
+    fn login_auth_config(&self) -> LoginAuthConfig {
+        LoginAuthConfig::from_config_toml(self.auth.clone())
     }
 }
 
@@ -2588,6 +2597,7 @@ impl Config {
                 .chatgpt_base_url
                 .or(cfg.chatgpt_base_url)
                 .unwrap_or("https://chatgpt.com/backend-api/".to_string()),
+            auth: cfg.auth,
             realtime_audio: cfg
                 .audio
                 .map_or_else(RealtimeAudioConfig::default, |audio| RealtimeAudioConfig {

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -10,12 +10,19 @@ use codex_protocol::auth::PlanType as InternalPlanType;
 use base64::Engine;
 use codex_protocol::config_types::ForcedLoginMethod;
 use codex_protocol::config_types::ModelProviderAuthInfo;
+use core_test_support::skip_if_no_network;
 use pretty_assertions::assert_eq;
 use serde::Serialize;
 use serde_json::json;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tempfile::tempdir;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_string_contains;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
 
 #[tokio::test]
 async fn refresh_without_id_token() {
@@ -36,6 +43,7 @@ async fn refresh_without_id_token() {
     );
     let updated = super::persist_tokens(
         &storage,
+        /*api_key*/ None,
         /*id_token*/ None,
         Some("new-access-token".to_string()),
         Some("new-refresh-token".to_string()),
@@ -46,6 +54,96 @@ async fn refresh_without_id_token() {
     assert_eq!(tokens.id_token.raw_jwt, fake_jwt);
     assert_eq!(tokens.access_token, "new-access-token");
     assert_eq!(tokens.refresh_token, "new-refresh-token");
+}
+
+#[tokio::test]
+async fn oidc_refresh_exchanges_refreshed_id_token_for_api_key() {
+    skip_if_no_network!();
+
+    let server = MockServer::start().await;
+    let refreshed_id_token = fake_jwt_for_auth_file_params(&AuthFileParams {
+        openai_api_key: None,
+        chatgpt_plan_type: None,
+        chatgpt_account_id: None,
+    })
+    .expect("fake jwt");
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains("refresh_token=test-refresh-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id_token": refreshed_id_token,
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains(
+            "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange",
+        ))
+        .and(body_string_contains(
+            "requested_token_type=urn%3Aamnezia-gpt%3Atoken-type%3Aapi_key",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "router-api-key",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let codex_home = tempdir().unwrap();
+    write_auth_file(
+        AuthFileParams {
+            openai_api_key: None,
+            chatgpt_plan_type: Some("pro".to_string()),
+            chatgpt_account_id: None,
+        },
+        codex_home.path(),
+    )
+    .expect("failed to write auth file");
+    let token_endpoint = format!("{}/oauth/token", server.uri());
+    let manager = AuthManager::new_with_auth_config(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+        crate::server::LoginAuthConfig {
+            issuer: server.uri(),
+            client_id: "amcode".to_string(),
+            scopes: vec!["openid".to_string()],
+            authorization_endpoint: None,
+            token_endpoint: Some(token_endpoint),
+            revocation_endpoint: None,
+            requested_token_type: Some("urn:amnezia-gpt:token-type:api_key".to_string()),
+            router_audience: Some("urn:amnezia-gpt:resource:router".to_string()),
+            include_openai_chatgpt_params: false,
+        },
+    )
+    .await;
+
+    manager
+        .refresh_token_from_authority()
+        .await
+        .expect("refresh should succeed");
+
+    let auth_dot_json = load_auth_dot_json(codex_home.path(), AuthCredentialsStoreMode::File)
+        .expect("auth file should load")
+        .expect("auth file should exist");
+    assert_eq!(
+        auth_dot_json.openai_api_key.as_deref(),
+        Some("router-api-key")
+    );
+    let tokens = auth_dot_json.tokens.expect("tokens should exist");
+    assert_eq!(tokens.access_token, "new-access-token");
+    assert_eq!(tokens.refresh_token, "new-refresh-token");
+
+    let auth = manager.auth().await.expect("auth should reload");
+    let token = auth.get_token().expect("token should resolve");
+    assert_eq!(token, "router-api-key");
+    server.verify().await;
 }
 
 #[test]

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -30,6 +30,8 @@ use crate::auth::storage::AuthStorageBackend;
 use crate::auth::storage::create_auth_storage;
 use crate::auth::util::try_parse_error_message;
 use crate::default_client::create_client;
+use crate::server::LoginAuthConfig;
+use crate::server::obtain_api_key;
 use crate::token_data::TokenData;
 use crate::token_data::parse_chatgpt_jwt_claims;
 use crate::token_data::parse_jwt_expiration;
@@ -313,8 +315,18 @@ impl CodexAuth {
         match self {
             Self::ApiKey(auth) => Ok(auth.api_key.clone()),
             Self::Chatgpt(_) | Self::ChatgptAuthTokens(_) => {
-                let access_token = self.get_token_data()?.access_token;
-                Ok(access_token)
+                let auth_dot_json = self
+                    .get_current_auth_json()
+                    .ok_or_else(|| std::io::Error::other("Token data is not available."))?;
+                // Configured OIDC stores the exchanged router API key in this legacy field for
+                // now so the existing bearer-token path can be reused.
+                if let Some(api_key) = auth_dot_json.openai_api_key {
+                    return Ok(api_key);
+                }
+                Ok(auth_dot_json
+                    .tokens
+                    .ok_or_else(|| std::io::Error::other("Token data is not available."))?
+                    .access_token)
             }
             Self::AgentIdentity(_) => Err(std::io::Error::other(
                 "agent identity auth does not expose a bearer token",
@@ -760,6 +772,7 @@ async fn load_auth(
 // Persist refreshed tokens into auth storage and update last_refresh.
 fn persist_tokens(
     storage: &Arc<dyn AuthStorageBackend>,
+    api_key: Option<String>,
     id_token: Option<String>,
     access_token: Option<String>,
     refresh_token: Option<String>,
@@ -777,6 +790,9 @@ fn persist_tokens(
     }
     if let Some(refresh_token) = refresh_token {
         tokens.refresh_token = refresh_token;
+    }
+    if let Some(api_key) = api_key {
+        auth_dot_json.openai_api_key = Some(api_key);
     }
     auth_dot_json.last_refresh = Some(Utc::now());
     storage.save(&auth_dot_json)?;
@@ -825,6 +841,47 @@ async fn request_chatgpt_token_refresh(
                 format!("Failed to refresh token: {status}: {message}"),
             )))
         }
+    }
+}
+
+async fn request_oidc_token_refresh(
+    auth_config: &LoginAuthConfig,
+    refresh_token: &str,
+    client: &CodexHttpClient,
+) -> Result<RefreshResponse, RefreshTokenError> {
+    let body = format!(
+        "grant_type={}&client_id={}&refresh_token={}",
+        urlencoding::encode("refresh_token"),
+        urlencoding::encode(&auth_config.client_id),
+        urlencoding::encode(refresh_token)
+    );
+
+    let response = client
+        .post(auth_config.token_endpoint().as_str())
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(body)
+        .send()
+        .await
+        .map_err(|err| RefreshTokenError::Transient(std::io::Error::other(err)))?;
+
+    let status = response.status();
+    if status.is_success() {
+        return response
+            .json::<RefreshResponse>()
+            .await
+            .map_err(|err| RefreshTokenError::Transient(std::io::Error::other(err)));
+    }
+
+    let body = response.text().await.unwrap_or_default();
+    tracing::error!("Failed to refresh OIDC token: {status}: {body}");
+    if status == StatusCode::UNAUTHORIZED {
+        let failed = classify_refresh_token_failure(&body);
+        Err(RefreshTokenError::Permanent(failed))
+    } else {
+        let message = try_parse_error_message(&body);
+        Err(RefreshTokenError::Transient(std::io::Error::other(
+            format!("Failed to refresh OIDC token: {status}: {message}"),
+        )))
     }
 }
 
@@ -1229,6 +1286,7 @@ pub struct AuthManager {
     auth_credentials_store_mode: AuthCredentialsStoreMode,
     forced_chatgpt_workspace_id: RwLock<Option<String>>,
     chatgpt_base_url: Option<String>,
+    auth_config: LoginAuthConfig,
     refresh_lock: Semaphore,
     external_auth: RwLock<Option<Arc<dyn ExternalAuth>>>,
 }
@@ -1251,6 +1309,11 @@ pub trait AuthManagerConfig {
 
     /// Returns the ChatGPT backend base URL used for first-party backend authorization.
     fn chatgpt_base_url(&self) -> String;
+
+    /// Returns the interactive login auth configuration used for token refresh.
+    fn login_auth_config(&self) -> LoginAuthConfig {
+        LoginAuthConfig::default()
+    }
 }
 
 impl Debug for AuthManager {
@@ -1268,6 +1331,7 @@ impl Debug for AuthManager {
                 &self.forced_chatgpt_workspace_id,
             )
             .field("chatgpt_base_url", &self.chatgpt_base_url)
+            .field("auth_config", &self.auth_config)
             .field("has_external_auth", &self.has_external_auth())
             .finish_non_exhaustive()
     }
@@ -1283,6 +1347,23 @@ impl AuthManager {
         enable_codex_api_key_env: bool,
         auth_credentials_store_mode: AuthCredentialsStoreMode,
         chatgpt_base_url: Option<String>,
+    ) -> Self {
+        Self::new_with_auth_config(
+            codex_home,
+            enable_codex_api_key_env,
+            auth_credentials_store_mode,
+            chatgpt_base_url,
+            LoginAuthConfig::default(),
+        )
+        .await
+    }
+
+    async fn new_with_auth_config(
+        codex_home: PathBuf,
+        enable_codex_api_key_env: bool,
+        auth_credentials_store_mode: AuthCredentialsStoreMode,
+        chatgpt_base_url: Option<String>,
+        auth_config: LoginAuthConfig,
     ) -> Self {
         let managed_auth = load_auth(
             &codex_home,
@@ -1302,6 +1383,7 @@ impl AuthManager {
             auth_credentials_store_mode,
             forced_chatgpt_workspace_id: RwLock::new(None),
             chatgpt_base_url,
+            auth_config,
             refresh_lock: Semaphore::new(/*permits*/ 1),
             external_auth: RwLock::new(None),
         }
@@ -1321,6 +1403,7 @@ impl AuthManager {
             auth_credentials_store_mode: AuthCredentialsStoreMode::File,
             forced_chatgpt_workspace_id: RwLock::new(None),
             chatgpt_base_url: None,
+            auth_config: LoginAuthConfig::default(),
             refresh_lock: Semaphore::new(/*permits*/ 1),
             external_auth: RwLock::new(None),
         })
@@ -1339,6 +1422,7 @@ impl AuthManager {
             auth_credentials_store_mode: AuthCredentialsStoreMode::File,
             forced_chatgpt_workspace_id: RwLock::new(None),
             chatgpt_base_url: None,
+            auth_config: LoginAuthConfig::default(),
             refresh_lock: Semaphore::new(/*permits*/ 1),
             external_auth: RwLock::new(None),
         })
@@ -1355,6 +1439,7 @@ impl AuthManager {
             auth_credentials_store_mode: AuthCredentialsStoreMode::File,
             forced_chatgpt_workspace_id: RwLock::new(None),
             chatgpt_base_url: None,
+            auth_config: LoginAuthConfig::default(),
             refresh_lock: Semaphore::new(/*permits*/ 1),
             external_auth: RwLock::new(Some(
                 Arc::new(BearerTokenRefresher::new(config)) as Arc<dyn ExternalAuth>
@@ -1573,16 +1658,36 @@ impl AuthManager {
         )
     }
 
+    async fn shared_with_auth_config(
+        codex_home: PathBuf,
+        enable_codex_api_key_env: bool,
+        auth_credentials_store_mode: AuthCredentialsStoreMode,
+        chatgpt_base_url: Option<String>,
+        auth_config: LoginAuthConfig,
+    ) -> Arc<Self> {
+        Arc::new(
+            Self::new_with_auth_config(
+                codex_home,
+                enable_codex_api_key_env,
+                auth_credentials_store_mode,
+                chatgpt_base_url,
+                auth_config,
+            )
+            .await,
+        )
+    }
+
     /// Convenience constructor returning an `Arc` wrapper from resolved config.
     pub async fn shared_from_config(
         config: &impl AuthManagerConfig,
         enable_codex_api_key_env: bool,
     ) -> Arc<Self> {
-        let auth_manager = Self::shared(
+        let auth_manager = Self::shared_with_auth_config(
             config.codex_home(),
             enable_codex_api_key_env,
             config.cli_auth_credentials_store_mode(),
             Some(config.chatgpt_base_url()),
+            config.login_auth_config(),
         )
         .await;
         auth_manager.set_forced_chatgpt_workspace_id(config.forced_chatgpt_workspace_id());
@@ -1843,10 +1948,26 @@ impl AuthManager {
         auth: &ChatgptAuth,
         refresh_token: String,
     ) -> Result<(), RefreshTokenError> {
-        let refresh_response = request_chatgpt_token_refresh(refresh_token, auth.client()).await?;
+        let refresh_response = if self.auth_config.include_openai_chatgpt_params {
+            request_chatgpt_token_refresh(refresh_token, auth.client()).await?
+        } else {
+            request_oidc_token_refresh(&self.auth_config, &refresh_token, auth.client()).await?
+        };
+        let api_key = if self.auth_config.include_openai_chatgpt_params {
+            None
+        } else if let Some(id_token) = refresh_response.id_token.as_deref() {
+            Some(
+                obtain_api_key(&self.auth_config, id_token)
+                    .await
+                    .map_err(RefreshTokenError::Transient)?,
+            )
+        } else {
+            None
+        };
 
         persist_tokens(
             auth.storage(),
+            api_key,
             refresh_response.id_token,
             refresh_response.access_token,
             refresh_response.refresh_token,

--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -157,6 +157,13 @@ fn print_device_code_prompt(verification_url: &str, code: &str) {
 }
 
 pub async fn request_device_code(opts: &ServerOptions) -> std::io::Result<DeviceCode> {
+    if !opts.auth_config.include_openai_chatgpt_params {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "device code login is only supported for ChatGPT auth. Use browser login for configured OIDC auth.",
+        ));
+    }
+
     let client = build_reqwest_client_with_custom_ca(reqwest::Client::builder())?;
     let base_url = opts.issuer.trim_end_matches('/');
     let api_base_url = format!("{base_url}/api/accounts");
@@ -194,8 +201,7 @@ pub async fn complete_device_code_login(
     let redirect_uri = format!("{base_url}/deviceauth/callback");
 
     let tokens = crate::server::exchange_code_for_tokens(
-        base_url,
-        &opts.client_id,
+        &opts.auth_config,
         &redirect_uri,
         &pkce,
         &code_resp.authorization_code,

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -12,9 +12,11 @@ pub use device_code_auth::DeviceCode;
 pub use device_code_auth::complete_device_code_login;
 pub use device_code_auth::request_device_code;
 pub use device_code_auth::run_device_code_login;
+pub use server::LoginAuthConfig;
 pub use server::LoginServer;
 pub use server::ServerOptions;
 pub use server::ShutdownHandle;
+pub use server::resolve_oidc_login_config;
 pub use server::run_login_server;
 
 pub use auth::AuthConfig;

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -35,7 +35,9 @@ use base64::Engine;
 use chrono::Utc;
 use codex_app_server_protocol::AuthMode;
 use codex_client::build_reqwest_client_with_custom_ca;
+use codex_config::types::AuthConfigToml;
 use codex_config::types::AuthCredentialsStoreMode;
+use codex_config::types::AuthEndpointConfigToml;
 use codex_utils_template::Template;
 use rand::RngCore;
 use serde_json::Value as JsonValue;
@@ -50,6 +52,11 @@ use tracing::warn;
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const DEFAULT_PORT: u16 = 1455;
+const DEFAULT_CLIENT_ID: &str = crate::auth::CLIENT_ID;
+const DEFAULT_TOKEN_EXCHANGE_REQUESTED_TOKEN: &str = "openai-api-key";
+const DEFAULT_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:id_token";
+const AMNEZIA_TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE: &str = "urn:amnezia-gpt:token-type:api_key";
+const AMNEZIA_ROUTER_AUDIENCE: &str = "urn:amnezia-gpt:resource:router";
 static LOGIN_ERROR_PAGE_TEMPLATE: LazyLock<Template> = LazyLock::new(|| {
     Template::parse(include_str!("assets/error.html"))
         .unwrap_or_else(|err| panic!("login error page template must parse: {err}"))
@@ -61,11 +68,195 @@ pub struct ServerOptions {
     pub codex_home: PathBuf,
     pub client_id: String,
     pub issuer: String,
+    pub auth_config: LoginAuthConfig,
     pub port: u16,
     pub open_browser: bool,
     pub force_state: Option<String>,
     pub forced_chatgpt_workspace_id: Option<String>,
     pub cli_auth_credentials_store_mode: AuthCredentialsStoreMode,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginAuthConfig {
+    pub issuer: String,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub authorization_endpoint: Option<String>,
+    pub token_endpoint: Option<String>,
+    pub revocation_endpoint: Option<String>,
+    pub requested_token_type: Option<String>,
+    pub router_audience: Option<String>,
+    pub include_openai_chatgpt_params: bool,
+}
+
+impl Default for LoginAuthConfig {
+    fn default() -> Self {
+        Self {
+            issuer: DEFAULT_ISSUER.to_string(),
+            client_id: DEFAULT_CLIENT_ID.to_string(),
+            scopes: vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+                "offline_access".to_string(),
+                "api.connectors.read".to_string(),
+                "api.connectors.invoke".to_string(),
+            ],
+            authorization_endpoint: None,
+            token_endpoint: None,
+            revocation_endpoint: None,
+            requested_token_type: None,
+            router_audience: None,
+            include_openai_chatgpt_params: true,
+        }
+    }
+}
+
+impl LoginAuthConfig {
+    pub fn from_config_toml(config: Option<AuthConfigToml>) -> Self {
+        let Some(config) = config else {
+            return Self::default();
+        };
+
+        let endpoints = config.endpoints.unwrap_or(AuthEndpointConfigToml {
+            authorization: None,
+            token: None,
+            revocation: None,
+        });
+        let issuer = config.issuer.unwrap_or_else(|| DEFAULT_ISSUER.to_string());
+        let client_id = config
+            .client_id
+            .unwrap_or_else(|| DEFAULT_CLIENT_ID.to_string());
+        let scopes = config.scopes.unwrap_or_else(|| {
+            vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+                "offline_access".to_string(),
+            ]
+        });
+
+        Self {
+            issuer,
+            client_id,
+            scopes,
+            authorization_endpoint: endpoints.authorization,
+            token_endpoint: endpoints.token,
+            revocation_endpoint: endpoints.revocation,
+            requested_token_type: config
+                .requested_token_type
+                .or_else(|| Some(AMNEZIA_TOKEN_EXCHANGE_REQUESTED_TOKEN_TYPE.to_string())),
+            router_audience: config
+                .router_audience
+                .or_else(|| Some(AMNEZIA_ROUTER_AUDIENCE.to_string())),
+            include_openai_chatgpt_params: false,
+        }
+    }
+
+    fn authorization_endpoint(&self) -> String {
+        self.authorization_endpoint
+            .clone()
+            .unwrap_or_else(|| format!("{}/oauth/authorize", self.issuer.trim_end_matches('/')))
+    }
+
+    pub(crate) fn token_endpoint(&self) -> String {
+        self.token_endpoint
+            .clone()
+            .unwrap_or_else(|| format!("{}/oauth/token", self.issuer.trim_end_matches('/')))
+    }
+
+    fn requested_token_type(&self) -> Option<&str> {
+        self.requested_token_type.as_deref()
+    }
+
+    fn router_audience(&self) -> Option<&str> {
+        self.router_audience.as_deref()
+    }
+
+    fn token_exchange_body(&self, subject_token: &str) -> String {
+        let mut form = vec![
+            (
+                "grant_type",
+                "urn:ietf:params:oauth:grant-type:token-exchange",
+            ),
+            ("client_id", self.client_id.as_str()),
+            ("subject_token", subject_token),
+            (
+                "subject_token_type",
+                DEFAULT_TOKEN_EXCHANGE_SUBJECT_TOKEN_TYPE,
+            ),
+        ];
+        if let Some(requested_token_type) = self.requested_token_type() {
+            form.push(("requested_token_type", requested_token_type));
+        } else {
+            form.push(("requested_token", DEFAULT_TOKEN_EXCHANGE_REQUESTED_TOKEN));
+        }
+        if let Some(audience) = self.router_audience() {
+            form.push(("audience", audience));
+        }
+        form.into_iter()
+            .map(|(key, value)| format!("{key}={}", urlencoding::encode(value)))
+            .collect::<Vec<_>>()
+            .join("&")
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OidcDiscoveryDocument {
+    authorization_endpoint: Option<String>,
+    token_endpoint: Option<String>,
+    revocation_endpoint: Option<String>,
+}
+
+pub async fn resolve_oidc_login_config(mut auth_config: LoginAuthConfig) -> LoginAuthConfig {
+    if auth_config.include_openai_chatgpt_params
+        || (auth_config.authorization_endpoint.is_some()
+            && auth_config.token_endpoint.is_some()
+            && auth_config.revocation_endpoint.is_some())
+    {
+        return auth_config;
+    }
+
+    let discovery_url = format!(
+        "{}/.well-known/openid-configuration",
+        auth_config.issuer.trim_end_matches('/')
+    );
+    let client = match build_reqwest_client_with_custom_ca(reqwest::Client::builder()) {
+        Ok(client) => client,
+        Err(err) => {
+            warn!("failed to build OIDC discovery client: {err}");
+            return auth_config;
+        }
+    };
+    let response = match client.get(discovery_url.as_str()).send().await {
+        Ok(response) => response,
+        Err(err) => {
+            warn!("OIDC discovery request failed for {discovery_url}: {err}");
+            return auth_config;
+        }
+    };
+    if !response.status().is_success() {
+        warn!(
+            "OIDC discovery request returned non-success status for {discovery_url}: {}",
+            response.status()
+        );
+        return auth_config;
+    }
+    let discovery = match response.json::<OidcDiscoveryDocument>().await {
+        Ok(discovery) => discovery,
+        Err(err) => {
+            warn!("failed to parse OIDC discovery document from {discovery_url}: {err}");
+            return auth_config;
+        }
+    };
+    auth_config.authorization_endpoint = auth_config
+        .authorization_endpoint
+        .or(discovery.authorization_endpoint);
+    auth_config.token_endpoint = auth_config.token_endpoint.or(discovery.token_endpoint);
+    auth_config.revocation_endpoint = auth_config
+        .revocation_endpoint
+        .or(discovery.revocation_endpoint);
+    auth_config
 }
 
 impl ServerOptions {
@@ -80,12 +271,20 @@ impl ServerOptions {
             codex_home,
             client_id,
             issuer: DEFAULT_ISSUER.to_string(),
+            auth_config: LoginAuthConfig::default(),
             port: DEFAULT_PORT,
             open_browser: true,
             force_state: None,
             forced_chatgpt_workspace_id,
             cli_auth_credentials_store_mode,
         }
+    }
+
+    pub fn with_auth_config(mut self, auth_config: LoginAuthConfig) -> Self {
+        self.client_id = auth_config.client_id.clone();
+        self.issuer = auth_config.issuer.clone();
+        self.auth_config = auth_config;
+        self
     }
 }
 
@@ -148,8 +347,7 @@ pub fn run_login_server(opts: ServerOptions) -> io::Result<LoginServer> {
 
     let redirect_uri = format!("http://localhost:{actual_port}/auth/callback");
     let auth_url = build_authorize_url(
-        &opts.issuer,
-        &opts.client_id,
+        &opts.auth_config,
         &redirect_uri,
         &pkce,
         &state,
@@ -328,9 +526,7 @@ async fn process_request(
                 }
             };
 
-            match exchange_code_for_tokens(&opts.issuer, &opts.client_id, redirect_uri, pkce, &code)
-                .await
-            {
+            match exchange_code_for_tokens(&opts.auth_config, redirect_uri, pkce, &code).await {
                 Ok(tokens) => {
                     if let Err(message) = ensure_workspace_allowed(
                         opts.forced_chatgpt_workspace_id.as_deref(),
@@ -344,8 +540,9 @@ async fn process_request(
                             /*error_description*/ None,
                         );
                     }
-                    // Obtain API key via token-exchange and persist
-                    let api_key = obtain_api_key(&opts.issuer, &opts.client_id, &tokens.id_token)
+                    // Configured OIDC reuses the legacy OPENAI_API_KEY auth.json field as a
+                    // transitional storage slot for the exchanged router API key.
+                    let api_key = obtain_api_key(&opts.auth_config, &tokens.id_token)
                         .await
                         .ok();
                     if let Err(err) = persist_tokens_async(
@@ -466,8 +663,7 @@ fn send_response_with_disconnect(
 }
 
 fn build_authorize_url(
-    issuer: &str,
-    client_id: &str,
+    auth_config: &LoginAuthConfig,
     redirect_uri: &str,
     pkce: &PkceCodes,
     state: &str,
@@ -475,24 +671,24 @@ fn build_authorize_url(
 ) -> String {
     let mut query = vec![
         ("response_type".to_string(), "code".to_string()),
-        ("client_id".to_string(), client_id.to_string()),
+        ("client_id".to_string(), auth_config.client_id.to_string()),
         ("redirect_uri".to_string(), redirect_uri.to_string()),
-        (
-            "scope".to_string(),
-            "openid profile email offline_access api.connectors.read api.connectors.invoke"
-                .to_string(),
-        ),
+        ("scope".to_string(), auth_config.scopes.join(" ")),
         (
             "code_challenge".to_string(),
             pkce.code_challenge.to_string(),
         ),
         ("code_challenge_method".to_string(), "S256".to_string()),
-        ("id_token_add_organizations".to_string(), "true".to_string()),
-        ("codex_cli_simplified_flow".to_string(), "true".to_string()),
         ("state".to_string(), state.to_string()),
-        ("originator".to_string(), originator().value),
     ];
-    if let Some(workspace_id) = forced_chatgpt_workspace_id {
+    if auth_config.include_openai_chatgpt_params {
+        query.push(("id_token_add_organizations".to_string(), "true".to_string()));
+        query.push(("codex_cli_simplified_flow".to_string(), "true".to_string()));
+        query.push(("originator".to_string(), originator().value));
+    }
+    if auth_config.include_openai_chatgpt_params
+        && let Some(workspace_id) = forced_chatgpt_workspace_id
+    {
         query.push(("allowed_workspace_id".to_string(), workspace_id.to_string()));
     }
     let qs = query
@@ -500,7 +696,7 @@ fn build_authorize_url(
         .map(|(k, v)| format!("{k}={}", urlencoding::encode(&v)))
         .collect::<Vec<_>>()
         .join("&");
-    format!("{issuer}/oauth/authorize?{qs}")
+    format!("{}?{qs}", auth_config.authorization_endpoint())
 }
 
 fn generate_state() -> String {
@@ -682,8 +878,7 @@ fn sanitize_url_for_logging(url: &str) -> String {
 /// fields from parsed token responses and redacted transport errors, but does not log the final
 /// callback-layer `%err` string.
 pub(crate) async fn exchange_code_for_tokens(
-    issuer: &str,
-    client_id: &str,
+    auth_config: &LoginAuthConfig,
     redirect_uri: &str,
     pkce: &PkceCodes,
     code: &str,
@@ -697,18 +892,18 @@ pub(crate) async fn exchange_code_for_tokens(
 
     let client = build_reqwest_client_with_custom_ca(reqwest::Client::builder())?;
     info!(
-        issuer = %sanitize_url_for_logging(issuer),
+        issuer = %sanitize_url_for_logging(&auth_config.issuer),
         redirect_uri = %redirect_uri,
         "starting oauth token exchange"
     );
     let resp = client
-        .post(format!("{issuer}/oauth/token"))
+        .post(auth_config.token_endpoint())
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(format!(
             "grant_type=authorization_code&code={}&redirect_uri={}&client_id={}&code_verifier={}",
             urlencoding::encode(code),
             urlencoding::encode(redirect_uri),
-            urlencoding::encode(client_id),
+            urlencoding::encode(&auth_config.client_id),
             urlencoding::encode(&pkce.code_verifier)
         ))
         .send()
@@ -1058,8 +1253,7 @@ fn html_escape(input: &str) -> String {
 
 /// Exchanges an authenticated ID token for an API-key style access token.
 pub(crate) async fn obtain_api_key(
-    issuer: &str,
-    client_id: &str,
+    auth_config: &LoginAuthConfig,
     id_token: &str,
 ) -> io::Result<String> {
     // Token exchange for an API key access token
@@ -1068,17 +1262,11 @@ pub(crate) async fn obtain_api_key(
         access_token: String,
     }
     let client = build_reqwest_client_with_custom_ca(reqwest::Client::builder())?;
+    let body = auth_config.token_exchange_body(id_token);
     let resp = client
-        .post(format!("{issuer}/oauth/token"))
+        .post(auth_config.token_endpoint())
         .header("Content-Type", "application/x-www-form-urlencoded")
-        .body(format!(
-            "grant_type={}&client_id={}&requested_token={}&subject_token={}&subject_token_type={}",
-            urlencoding::encode("urn:ietf:params:oauth:grant-type:token-exchange"),
-            urlencoding::encode(client_id),
-            urlencoding::encode("openai-api-key"),
-            urlencoding::encode(id_token),
-            urlencoding::encode("urn:ietf:params:oauth:token-type:id_token")
-        ))
+        .body(body)
         .send()
         .await
         .map_err(io::Error::other)?;
@@ -1095,7 +1283,9 @@ pub(crate) async fn obtain_api_key(
 mod tests {
     use pretty_assertions::assert_eq;
 
+    use super::LoginAuthConfig;
     use super::TokenEndpointErrorDetail;
+    use super::build_authorize_url;
     use super::html_escape;
     use super::is_missing_codex_entitlement_error;
     use super::parse_token_endpoint_error;
@@ -1103,6 +1293,78 @@ mod tests {
     use super::redact_sensitive_url_parts;
     use super::render_login_error_page;
     use super::sanitize_url_for_logging;
+    use crate::pkce::PkceCodes;
+
+    #[test]
+    fn configured_oidc_auth_url_omits_openai_specific_params() {
+        let auth_config = LoginAuthConfig {
+            issuer: "https://auth.example.com".to_string(),
+            client_id: "amcode".to_string(),
+            scopes: vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+                "offline_access".to_string(),
+            ],
+            authorization_endpoint: None,
+            token_endpoint: None,
+            revocation_endpoint: None,
+            requested_token_type: Some("urn:amnezia-gpt:token-type:api_key".to_string()),
+            router_audience: Some("urn:amnezia-gpt:resource:router".to_string()),
+            include_openai_chatgpt_params: false,
+        };
+        let pkce = PkceCodes {
+            code_verifier: "verifier".to_string(),
+            code_challenge: "challenge".to_string(),
+        };
+
+        let url = build_authorize_url(
+            &auth_config,
+            "http://localhost:1455/auth/callback",
+            &pkce,
+            "state",
+            Some("workspace"),
+        );
+
+        assert!(url.starts_with("https://auth.example.com/oauth/authorize?"));
+        assert!(url.contains("client_id=amcode"));
+        assert!(url.contains("scope=openid%20profile%20email%20offline_access"));
+        assert!(!url.contains("api.connectors.read"));
+        assert!(!url.contains("api.connectors.invoke"));
+        assert!(!url.contains("id_token_add_organizations"));
+        assert!(!url.contains("codex_cli_simplified_flow"));
+        assert!(!url.contains("originator"));
+        assert!(!url.contains("allowed_workspace_id"));
+    }
+
+    #[test]
+    fn configured_oidc_token_exchange_requests_router_api_key() {
+        let auth_config = LoginAuthConfig {
+            issuer: "https://auth.example.com".to_string(),
+            client_id: "amcode".to_string(),
+            scopes: vec!["openid".to_string()],
+            authorization_endpoint: None,
+            token_endpoint: None,
+            revocation_endpoint: None,
+            requested_token_type: Some("urn:amnezia-gpt:token-type:api_key".to_string()),
+            router_audience: Some("urn:amnezia-gpt:resource:router".to_string()),
+            include_openai_chatgpt_params: false,
+        };
+
+        let body = auth_config.token_exchange_body("id-token");
+
+        assert!(
+            body.contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange")
+        );
+        assert!(body.contains("client_id=amcode"));
+        assert!(body.contains("subject_token=id-token"));
+        assert!(
+            body.contains("subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Aid_token")
+        );
+        assert!(body.contains("requested_token_type=urn%3Aamnezia-gpt%3Atoken-type%3Aapi_key"));
+        assert!(body.contains("audience=urn%3Aamnezia-gpt%3Aresource%3Arouter"));
+        assert!(!body.contains("requested_token=openai-api-key"));
+    }
 
     #[test]
     fn parse_token_endpoint_error_prefers_error_description() {

--- a/codex-rs/login/tests/suite/device_code_login.rs
+++ b/codex-rs/login/tests/suite/device_code_login.rs
@@ -6,6 +6,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_login::ServerOptions;
 use codex_login::auth::load_auth_dot_json;
+use codex_login::request_device_code;
 use codex_login::run_device_code_login;
 use serde_json::json;
 use std::sync::Arc;
@@ -109,8 +110,32 @@ fn server_opts(
         cli_auth_credentials_store_mode,
     );
     opts.issuer = issuer;
+    opts.auth_config.issuer = opts.issuer.clone();
+    opts.auth_config.client_id = opts.client_id.clone();
     opts.open_browser = false;
     opts
+}
+
+#[tokio::test]
+async fn device_code_login_is_disabled_for_configured_oidc_auth() -> anyhow::Result<()> {
+    let codex_home = tempdir().unwrap();
+    let mut opts = server_opts(
+        &codex_home,
+        "https://auth.example.test".to_string(),
+        AuthCredentialsStoreMode::File,
+    );
+    opts.auth_config.include_openai_chatgpt_params = false;
+
+    let err = request_device_code(&opts)
+        .await
+        .expect_err("configured OIDC auth should not use legacy device-code endpoints");
+
+    assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    assert!(
+        err.to_string()
+            .contains("Use browser login for configured OIDC auth")
+    );
+    Ok(())
 }
 
 #[tokio::test]

--- a/codex-rs/login/tests/suite/login_server_e2e.rs
+++ b/codex-rs/login/tests/suite/login_server_e2e.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use anyhow::Result;
 use base64::Engine;
 use codex_config::types::AuthCredentialsStoreMode;
+use codex_login::LoginAuthConfig;
 use codex_login::ServerOptions;
 use codex_login::run_login_server;
 use core_test_support::skip_if_no_network;
@@ -78,6 +79,13 @@ fn start_mock_issuer(chatgpt_account_id: &str) -> (SocketAddr, thread::JoinHandl
     (addr, handle)
 }
 
+fn mock_login_auth_config(issuer: &str) -> LoginAuthConfig {
+    LoginAuthConfig {
+        issuer: issuer.to_string(),
+        ..Default::default()
+    }
+}
+
 #[tokio::test]
 async fn end_to_end_login_flow_persists_auth_json() -> Result<()> {
     skip_if_no_network!(Ok(()));
@@ -113,7 +121,8 @@ async fn end_to_end_login_flow_persists_auth_json() -> Result<()> {
         codex_home: server_home,
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
-        issuer,
+        issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: 0,
         open_browser: false,
         force_state: Some(state),
@@ -174,7 +183,8 @@ async fn creates_missing_codex_home_dir() -> Result<()> {
         codex_home: server_home,
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
-        issuer,
+        issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: 0,
         open_browser: false,
         force_state: Some(state),
@@ -213,7 +223,8 @@ async fn forced_chatgpt_workspace_id_mismatch_blocks_login() -> Result<()> {
         codex_home: codex_home.clone(),
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
-        issuer,
+        issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: 0,
         open_browser: false,
         force_state: Some(state.clone()),
@@ -270,7 +281,8 @@ async fn oauth_access_denied_missing_entitlement_blocks_login_with_clear_error()
         codex_home: codex_home.clone(),
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
-        issuer,
+        issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: 0,
         open_browser: false,
         force_state: Some(state.clone()),
@@ -337,7 +349,8 @@ async fn oauth_access_denied_unknown_reason_uses_generic_error_page() -> Result<
         codex_home: codex_home.clone(),
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
-        issuer,
+        issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: 0,
         open_browser: false,
         force_state: Some(state.clone()),
@@ -416,6 +429,7 @@ async fn cancels_previous_login_server_when_port_is_in_use() -> Result<()> {
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
         issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: 0,
         open_browser: false,
         force_state: Some("cancel_state".to_string()),
@@ -435,7 +449,8 @@ async fn cancels_previous_login_server_when_port_is_in_use() -> Result<()> {
         codex_home: second_codex_home,
         cli_auth_credentials_store_mode: AuthCredentialsStoreMode::File,
         client_id: codex_login::CLIENT_ID.to_string(),
-        issuer,
+        issuer: issuer.clone(),
+        auth_config: mock_login_auth_config(&issuer),
         port: login_port,
         open_browser: false,
         force_state: Some("cancel_state_2".to_string()),


### PR DESCRIPTION
## Summary

Closes #3.

Adds the first Amnezia/OIDC auth slice for amcode:

- adds `[auth]` config and generated schema fields for issuer/client/scopes/token-exchange settings;
- resolves OIDC endpoints from `{issuer}/.well-known/openid-configuration` with explicit endpoint overrides;
- updates browser login and app-server login to use configured/discovered auth endpoints;
- omits OpenAI connector scopes and OpenAI-only authorize params for configured OIDC auth;
- exchanges authorization codes against the configured token endpoint;
- exchanges OIDC `id_token` for an Amnezia router API key using `requested_token_type=urn:amnezia-gpt:token-type:api_key` and router audience;
- stores the exchanged router key in the existing `OPENAI_API_KEY` auth.json field as a transitional compatibility choice;
- refreshes configured OIDC tokens and re-runs router API-key token exchange;
- disables legacy device-code login for configured OIDC auth.

## Local validation

- `cargo check -p codex-login -p codex-core -p codex-cli -p codex-app-server`
- `cargo test -p codex-login`
- `just fix -p codex-login`
- `just fmt`

End-to-end local validation against `agpt_auth` + router:

- `amcode login` completed OIDC browser login via `http://127.0.0.1:8000`;
- loopback callback `http://localhost:1455/auth/callback` was accepted;
- `auth.json` contained OAuth tokens plus `OPENAI_API_KEY` with `agpt_pat_` prefix;
- router accepted the exchanged PAT: `GET /v1/models` returned `200 OK`.

## Follow-ups

- #6: replace Codex/OpenAI branding on the local login success page for amcode/OIDC login.
- Wire logout/revoke to configured `revocation_endpoint`.
- Remove or normalize legacy ChatGPT-claim warnings for standard OIDC `id_token`.
- Add docs/examples after final production issuer/client id are known.
- #4: router provider/base URL/model behavior.
