### PR TITLE
Use configured OIDC revoke endpoint on logout

### DIFF
--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -15,7 +15,7 @@ use codex_login::LoginAuthConfig;
 use codex_login::ServerOptions;
 use codex_login::login_with_agent_identity;
 use codex_login::login_with_api_key;
-use codex_login::logout_with_revoke;
+use codex_login::logout_with_revoke_with_auth_config;
 use codex_login::resolve_oidc_login_config;
 use codex_login::run_device_code_login;
 use codex_login::run_login_server;
@@ -415,8 +415,16 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
 
 pub async fn run_logout(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides).await;
+    let auth_config =
+        resolve_oidc_login_config(LoginAuthConfig::from_config_toml(config.auth.clone())).await;
 
-    match logout_with_revoke(&config.codex_home, config.cli_auth_credentials_store_mode).await {
+    match logout_with_revoke_with_auth_config(
+        &config.codex_home,
+        config.cli_auth_credentials_store_mode,
+        auth_config,
+    )
+    .await
+    {
         Ok(true) => {
             eprintln!("Successfully logged out");
             std::process::exit(0);

--- a/codex-rs/login/src/assets/success.html
+++ b/codex-rs/login/src/assets/success.html
@@ -195,4 +195,3 @@
     </script>
   </body>
   </html>
-  

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -519,11 +519,25 @@ pub async fn logout_with_revoke(
     codex_home: &Path,
     auth_credentials_store_mode: AuthCredentialsStoreMode,
 ) -> std::io::Result<bool> {
-    AuthManager::new(
+    logout_with_revoke_with_auth_config(
+        codex_home,
+        auth_credentials_store_mode,
+        LoginAuthConfig::default(),
+    )
+    .await
+}
+
+pub async fn logout_with_revoke_with_auth_config(
+    codex_home: &Path,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+    auth_config: LoginAuthConfig,
+) -> std::io::Result<bool> {
+    AuthManager::new_with_auth_config(
         codex_home.to_path_buf(),
         /*enable_codex_api_key_env*/ false,
         auth_credentials_store_mode,
         /*chatgpt_base_url*/ None,
+        auth_config,
     )
     .await
     .logout_with_revoke()
@@ -1840,7 +1854,7 @@ impl AuthManager {
         let auth_dot_json = self
             .auth_cached()
             .and_then(|auth| auth.get_current_auth_json());
-        if let Err(err) = revoke_auth_tokens(auth_dot_json.as_ref()).await {
+        if let Err(err) = revoke_auth_tokens(auth_dot_json.as_ref(), &self.auth_config).await {
             tracing::warn!("failed to revoke auth tokens during logout: {err}");
         }
         let result = logout_all_stores(&self.codex_home, self.auth_credentials_store_mode)?;

--- a/codex-rs/login/src/auth/revoke.rs
+++ b/codex-rs/login/src/auth/revoke.rs
@@ -17,6 +17,7 @@ use super::manager::REVOKE_TOKEN_URL_OVERRIDE_ENV_VAR;
 use super::storage::AuthDotJson;
 use super::util::try_parse_error_message;
 use crate::default_client::create_client;
+use crate::server::LoginAuthConfig;
 use crate::token_data::TokenData;
 
 const REVOKE_HTTP_TIMEOUT: Duration = Duration::from_secs(10);
@@ -34,13 +35,6 @@ impl RevokeTokenKind {
             Self::Refresh => "refresh_token",
         }
     }
-
-    fn client_id(self) -> Option<&'static str> {
-        match self {
-            Self::Access => None,
-            Self::Refresh => Some(CLIENT_ID),
-        }
-    }
 }
 
 #[derive(Serialize)]
@@ -48,24 +42,26 @@ struct RevokeTokenRequest<'a> {
     token: &'a str,
     token_type_hint: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_id: Option<&'static str>,
+    client_id: Option<&'a str>,
 }
 
 pub(super) async fn revoke_auth_tokens(
     auth_dot_json: Option<&AuthDotJson>,
+    auth_config: &LoginAuthConfig,
 ) -> Result<(), std::io::Error> {
     let Some(tokens) = auth_dot_json.and_then(managed_chatgpt_tokens) else {
         return Ok(());
     };
 
     let client = create_client();
-    let endpoint = revoke_token_endpoint();
+    let endpoint = revoke_token_endpoint(auth_config);
     if !tokens.refresh_token.is_empty() {
         revoke_oauth_token(
             &client,
             endpoint.as_str(),
             tokens.refresh_token.as_str(),
             RevokeTokenKind::Refresh,
+            refresh_revoke_client_id(auth_config),
             REVOKE_HTTP_TIMEOUT,
         )
         .await
@@ -75,6 +71,7 @@ pub(super) async fn revoke_auth_tokens(
             endpoint.as_str(),
             tokens.access_token.as_str(),
             RevokeTokenKind::Access,
+            None,
             REVOKE_HTTP_TIMEOUT,
         )
         .await
@@ -106,12 +103,13 @@ async fn revoke_oauth_token(
     endpoint: &str,
     token: &str,
     kind: RevokeTokenKind,
+    client_id: Option<&str>,
     timeout: Duration,
 ) -> Result<(), std::io::Error> {
     let request = RevokeTokenRequest {
         token,
         token_type_hint: kind.as_str(),
-        client_id: kind.client_id(),
+        client_id,
     };
 
     let response = client
@@ -138,7 +136,11 @@ async fn revoke_oauth_token(
     )))
 }
 
-fn revoke_token_endpoint() -> String {
+fn revoke_token_endpoint(auth_config: &LoginAuthConfig) -> String {
+    if !auth_config.include_openai_chatgpt_params {
+        return auth_config.revocation_endpoint();
+    }
+
     if let Ok(endpoint) = std::env::var(REVOKE_TOKEN_URL_OVERRIDE_ENV_VAR) {
         return endpoint;
     }
@@ -150,6 +152,14 @@ fn revoke_token_endpoint() -> String {
     }
 
     REVOKE_TOKEN_URL.to_string()
+}
+
+fn refresh_revoke_client_id(auth_config: &LoginAuthConfig) -> Option<&str> {
+    if auth_config.include_openai_chatgpt_params {
+        Some(CLIENT_ID)
+    } else {
+        Some(auth_config.client_id.as_str())
+    }
 }
 
 fn derive_revoke_token_endpoint(refresh_endpoint: &str) -> Option<String> {
@@ -195,6 +205,7 @@ mod tests {
             endpoint.as_str(),
             "refresh-token",
             RevokeTokenKind::Refresh,
+            Some(CLIENT_ID),
             Duration::from_millis(20),
         )
         .await

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -44,6 +44,7 @@ pub use auth::login_with_agent_identity;
 pub use auth::login_with_api_key;
 pub use auth::logout;
 pub use auth::logout_with_revoke;
+pub use auth::logout_with_revoke_with_auth_config;
 pub use auth::read_codex_agent_identity_from_env;
 pub use auth::read_openai_api_key_from_env;
 pub use auth::save_auth;

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -165,6 +165,12 @@ impl LoginAuthConfig {
             .unwrap_or_else(|| format!("{}/oauth/token", self.issuer.trim_end_matches('/')))
     }
 
+    pub(crate) fn revocation_endpoint(&self) -> String {
+        self.revocation_endpoint
+            .clone()
+            .unwrap_or_else(|| format!("{}/oauth/revoke", self.issuer.trim_end_matches('/')))
+    }
+
     fn requested_token_type(&self) -> Option<&str> {
         self.requested_token_type.as_deref()
     }
@@ -567,6 +573,7 @@ async fn process_request(
                     let success_url = compose_success_url(
                         actual_port,
                         &opts.issuer,
+                        opts.auth_config.include_openai_chatgpt_params,
                         &tokens.id_token,
                         &tokens.access_token,
                     );
@@ -984,7 +991,13 @@ pub(crate) async fn persist_tokens_async(
     .map_err(|e| io::Error::other(format!("persist task failed: {e}")))?
 }
 
-fn compose_success_url(port: u16, issuer: &str, id_token: &str, access_token: &str) -> String {
+fn compose_success_url(
+    port: u16,
+    issuer: &str,
+    include_openai_chatgpt_params: bool,
+    id_token: &str,
+    access_token: &str,
+) -> String {
     let token_claims = jwt_auth_claims(id_token);
     let access_claims = jwt_auth_claims(access_token);
 
@@ -1012,8 +1025,10 @@ fn compose_success_url(port: u16, issuer: &str, id_token: &str, access_token: &s
 
     let platform_url = if issuer == DEFAULT_ISSUER {
         "https://platform.openai.com"
-    } else {
+    } else if include_openai_chatgpt_params {
         "https://platform.api.openai.org"
+    } else {
+        issuer.trim_end_matches('/')
     };
 
     let mut params = vec![
@@ -1286,6 +1301,7 @@ mod tests {
     use super::LoginAuthConfig;
     use super::TokenEndpointErrorDetail;
     use super::build_authorize_url;
+    use super::compose_success_url;
     use super::html_escape;
     use super::is_missing_codex_entitlement_error;
     use super::parse_token_endpoint_error;
@@ -1364,6 +1380,22 @@ mod tests {
         assert!(body.contains("requested_token_type=urn%3Aamnezia-gpt%3Atoken-type%3Aapi_key"));
         assert!(body.contains("audience=urn%3Aamnezia-gpt%3Aresource%3Arouter"));
         assert!(!body.contains("requested_token=openai-api-key"));
+    }
+
+    #[test]
+    fn configured_oidc_success_url_uses_issuer_as_platform_url() {
+        let url = compose_success_url(
+            /*port*/ 1455,
+            "https://auth.example.com/",
+            /*include_openai_chatgpt_params*/ false,
+            "header.payload.signature",
+            "access.header.payload",
+        );
+
+        assert!(url.starts_with("http://localhost:1455/success?"));
+        assert!(url.contains("id_token=header.payload.signature"));
+        assert!(url.contains("platform_url=https%3A%2F%2Fauth.example.com"));
+        assert!(!url.contains("platform.api.openai.org"));
     }
 
     #[test]

--- a/codex-rs/login/tests/suite/logout.rs
+++ b/codex-rs/login/tests/suite/logout.rs
@@ -6,8 +6,10 @@ use codex_config::types::AuthCredentialsStoreMode;
 use codex_login::AuthDotJson;
 use codex_login::AuthManager;
 use codex_login::CLIENT_ID;
+use codex_login::LoginAuthConfig;
 use codex_login::REVOKE_TOKEN_URL_OVERRIDE_ENV_VAR;
 use codex_login::logout_with_revoke;
+use codex_login::logout_with_revoke_with_auth_config;
 use codex_login::save_auth;
 use codex_login::token_data::IdTokenInfo;
 use codex_login::token_data::TokenData;
@@ -70,6 +72,69 @@ async fn logout_with_revoke_revokes_refresh_token_then_removes_auth() -> Result<
             "token": REFRESH_TOKEN,
             "token_type_hint": "refresh_token",
             "client_id": CLIENT_ID,
+        })
+    );
+    server.verify().await;
+    Ok(())
+}
+
+#[serial_test::serial(logout_revoke)]
+#[tokio::test]
+async fn logout_with_revoke_uses_configured_oidc_revocation_endpoint_and_client_id() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/revoke"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "message": "success"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &chatgpt_auth(),
+        AuthCredentialsStoreMode::File,
+    )?;
+
+    let auth_config = LoginAuthConfig {
+        issuer: server.uri(),
+        client_id: "router-ui-public".to_string(),
+        scopes: vec!["openid".to_string(), "offline_access".to_string()],
+        authorization_endpoint: Some(format!("{}/oauth/authorize", server.uri())),
+        token_endpoint: Some(format!("{}/oauth/token", server.uri())),
+        revocation_endpoint: Some(format!("{}/oauth/revoke", server.uri())),
+        requested_token_type: Some("urn:amnezia-gpt:token-type:api_key".to_string()),
+        router_audience: Some("urn:amnezia-gpt:resource:router".to_string()),
+        include_openai_chatgpt_params: false,
+    };
+
+    let removed = logout_with_revoke_with_auth_config(
+        codex_home.path(),
+        AuthCredentialsStoreMode::File,
+        auth_config,
+    )
+    .await?;
+
+    assert!(removed);
+    assert!(!codex_home.path().join("auth.json").exists());
+
+    let requests = server
+        .received_requests()
+        .await
+        .context("failed to fetch revoke requests")?;
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0]
+            .body_json::<Value>()
+            .context("revoke request should be JSON")?,
+        json!({
+            "token": REFRESH_TOKEN,
+            "token_type_hint": "refresh_token",
+            "client_id": "router-ui-public",
         })
     );
     server.verify().await;


### PR DESCRIPTION
## Summary
- resolve logout auth config from configured OIDC issuer discovery before revocation
- call the configured revocation endpoint with the configured client_id instead of OpenAI defaults
- keep local auth cleanup behavior and preserve legacy OpenAI logout behavior
- set configured-OIDC success platform_url from the configured issuer instead of OpenAI platform defaults

## Verification
- cargo test -p codex-login
- just fix -p codex-login
- live smoke: login through local agpt-auth, router access succeeds before logout, amcode logout revokes tokens and deletes auth.json, router access returns 401 after logout

Closes #9