### PR TITLE
Brand managed auth for Amnezia

### DIFF
--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -33,9 +33,9 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
 const CHATGPT_LOGIN_DISABLED_MESSAGE: &str =
-    "ChatGPT login is disabled. Use API key login instead.";
+    "Amnezia login is disabled. Use API key login instead.";
 const API_KEY_LOGIN_DISABLED_MESSAGE: &str =
-    "API key login is disabled. Use ChatGPT login instead.";
+    "API key login is disabled. Use Amnezia login instead.";
 const AGENT_IDENTITY_LOGIN_DISABLED_MESSAGE: &str =
     "Agent Identity login is disabled. Use API key login instead.";
 const LOGIN_SUCCESS_MESSAGE: &str = "Successfully logged in";
@@ -394,7 +394,7 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
                 }
             },
             AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens => {
-                eprintln!("Logged in using ChatGPT");
+                eprintln!("Logged in using Amnezia");
                 std::process::exit(0);
             }
             AuthMode::AgentIdentity => {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -220,6 +220,8 @@ pub enum Feature {
     ResponsesWebsocketsV2,
     /// Enable workspace dependency support.
     WorkspaceDependencies,
+    /// Allow the TUI to show device-code login.
+    CustomOidcDeviceCodeAuth,
 }
 
 impl Feature {
@@ -1047,6 +1049,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "workspace_dependencies",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::CustomOidcDeviceCodeAuth,
+        key: "custom_oidc_device_code_auth",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
 ];
 

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -247,6 +247,19 @@ fn workspace_dependencies_is_stable_and_enabled_by_default() {
 }
 
 #[test]
+fn custom_oidc_device_code_auth_is_under_development_and_disabled_by_default() {
+    assert_eq!(
+        Feature::CustomOidcDeviceCodeAuth.stage(),
+        Stage::UnderDevelopment
+    );
+    assert_eq!(Feature::CustomOidcDeviceCodeAuth.default_enabled(), false);
+    assert_eq!(
+        feature_for_key("custom_oidc_device_code_auth"),
+        Some(Feature::CustomOidcDeviceCodeAuth)
+    );
+}
+
+#[test]
 fn telepathy_is_legacy_alias_for_chronicle() {
     assert_eq!(Feature::Chronicle.stage(), Stage::UnderDevelopment);
     assert_eq!(Feature::Chronicle.default_enabled(), false);

--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -148,8 +148,8 @@ async fn poll_for_token(
 fn print_device_code_prompt(verification_url: &str, code: &str) {
     let version = env!("CARGO_PKG_VERSION");
     println!(
-        "\nWelcome to Codex [v{ANSI_GRAY}{version}{ANSI_RESET}]\n{ANSI_GRAY}OpenAI's command-line coding agent{ANSI_RESET}\n\
-\nFollow these steps to sign in with ChatGPT using device code authorization:\n\
+        "\nWelcome to Amcode [v{ANSI_GRAY}{version}{ANSI_RESET}]\n{ANSI_GRAY}Amnezia's command-line coding agent{ANSI_RESET}\n\
+\nFollow these steps to sign in with Amnezia using device code authorization:\n\
 \n1. Open this link in your browser and sign in to your account\n   {ANSI_BLUE}{verification_url}{ANSI_RESET}\n\
 \n2. Enter this one-time code {ANSI_GRAY}(expires in 15 minutes){ANSI_RESET}\n   {ANSI_BLUE}{code}{ANSI_RESET}\n\
 \n{ANSI_GRAY}Device codes are a common phishing target. Never share this code.{ANSI_RESET}\n",
@@ -160,7 +160,7 @@ pub async fn request_device_code(opts: &ServerOptions) -> std::io::Result<Device
     if !opts.auth_config.include_openai_chatgpt_params {
         return Err(io::Error::new(
             io::ErrorKind::NotFound,
-            "device code login is only supported for ChatGPT auth. Use browser login for configured OIDC auth.",
+            "device code login is not enabled for this auth server. Use browser login instead.",
         ));
     }
 

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -972,12 +972,7 @@ pub(crate) async fn persist_tokens_async(
             refresh_token,
             account_id: None,
         };
-        if let Some(acc) = jwt_auth_claims(&id_token)
-            .get("chatgpt_account_id")
-            .and_then(|v| v.as_str())
-        {
-            tokens.account_id = Some(acc.to_string());
-        }
+        tokens.account_id = tokens.id_token.chatgpt_account_id.clone();
         let auth = AuthDotJson {
             auth_mode: Some(AuthMode::Chatgpt),
             openai_api_key: api_key,
@@ -1018,10 +1013,8 @@ fn compose_success_url(
         .and_then(JsonValue::as_bool)
         .unwrap_or(false);
     let needs_setup = (!completed_onboarding) && is_org_owner;
-    let plan_type = access_claims
-        .get("chatgpt_plan_type")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let plan_type =
+        auth_claim_str(&access_claims, "amnezia_plan_type", "chatgpt_plan_type").unwrap_or("");
 
     let platform_url = if issuer == DEFAULT_ISSUER {
         "https://platform.openai.com"
@@ -1060,12 +1053,18 @@ fn jwt_auth_claims(jwt: &str) -> serde_json::Map<String, serde_json::Value> {
         Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
             Ok(mut v) => {
                 if let Some(obj) = v
+                    .get_mut("https://gpt.amnezia.org/auth")
+                    .and_then(|x| x.as_object_mut())
+                {
+                    return obj.clone();
+                }
+                if let Some(obj) = v
                     .get_mut("https://api.openai.com/auth")
                     .and_then(|x| x.as_object_mut())
                 {
                     return obj.clone();
                 }
-                eprintln!("JWT payload missing expected 'https://api.openai.com/auth' object");
+                eprintln!("JWT payload missing expected auth claims object");
             }
             Err(e) => {
                 eprintln!("Failed to parse JWT JSON payload: {e}");
@@ -1078,6 +1077,17 @@ fn jwt_auth_claims(jwt: &str) -> serde_json::Map<String, serde_json::Value> {
     serde_json::Map::new()
 }
 
+fn auth_claim_str<'a>(
+    claims: &'a serde_json::Map<String, serde_json::Value>,
+    amnezia_key: &str,
+    legacy_key: &str,
+) -> Option<&'a str> {
+    claims
+        .get(amnezia_key)
+        .or_else(|| claims.get(legacy_key))
+        .and_then(JsonValue::as_str)
+}
+
 /// Validates the ID token against an optional workspace restriction.
 pub(crate) fn ensure_workspace_allowed(
     expected: Option<&str>,
@@ -1087,9 +1097,9 @@ pub(crate) fn ensure_workspace_allowed(
         return Ok(());
     };
 
-    let claims = jwt_auth_claims(id_token);
-    let Some(actual) = claims.get("chatgpt_account_id").and_then(JsonValue::as_str) else {
-        return Err("Login is restricted to a specific workspace, but the token did not include an chatgpt_account_id claim.".to_string());
+    let token_info = parse_chatgpt_jwt_claims(id_token).map_err(|error| error.to_string())?;
+    let Some(actual) = token_info.chatgpt_account_id.as_deref() else {
+        return Err("Login is restricted to a specific workspace, but the token did not include an account id claim.".to_string());
     };
 
     if actual == expected {
@@ -1296,12 +1306,15 @@ pub(crate) async fn obtain_api_key(
 }
 #[cfg(test)]
 mod tests {
+    use base64::Engine;
     use pretty_assertions::assert_eq;
+    use serde::Serialize;
 
     use super::LoginAuthConfig;
     use super::TokenEndpointErrorDetail;
     use super::build_authorize_url;
     use super::compose_success_url;
+    use super::ensure_workspace_allowed;
     use super::html_escape;
     use super::is_missing_codex_entitlement_error;
     use super::parse_token_endpoint_error;
@@ -1310,6 +1323,27 @@ mod tests {
     use super::render_login_error_page;
     use super::sanitize_url_for_logging;
     use crate::pkce::PkceCodes;
+
+    fn fake_jwt(payload: serde_json::Value) -> String {
+        #[derive(Serialize)]
+        struct Header {
+            alg: &'static str,
+            typ: &'static str,
+        }
+        let header = Header {
+            alg: "none",
+            typ: "JWT",
+        };
+
+        fn b64url_no_pad(bytes: &[u8]) -> String {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+        }
+
+        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).unwrap());
+        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).unwrap());
+        let signature_b64 = b64url_no_pad(b"sig");
+        format!("{header_b64}.{payload_b64}.{signature_b64}")
+    }
 
     #[test]
     fn configured_oidc_auth_url_omits_openai_specific_params() {
@@ -1396,6 +1430,34 @@ mod tests {
         assert!(url.contains("id_token=header.payload.signature"));
         assert!(url.contains("platform_url=https%3A%2F%2Fauth.example.com"));
         assert!(!url.contains("platform.api.openai.org"));
+    }
+
+    #[test]
+    fn workspace_validation_accepts_amnezia_account_claim() {
+        let id_token = fake_jwt(serde_json::json!({
+            "https://gpt.amnezia.org/auth": {
+                "amnezia_account_id": "account-123"
+            }
+        }));
+
+        assert_eq!(
+            ensure_workspace_allowed(Some("account-123"), &id_token),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn workspace_validation_keeps_legacy_account_claim_fallback() {
+        let id_token = fake_jwt(serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_account_id": "account-123"
+            }
+        }));
+
+        assert_eq!(
+            ensure_workspace_allowed(Some("account-123"), &id_token),
+            Ok(())
+        );
     }
 
     #[test]

--- a/codex-rs/login/src/token_data.rs
+++ b/codex-rs/login/src/token_data.rs
@@ -74,6 +74,8 @@ struct IdClaims {
     email: Option<String>,
     #[serde(rename = "https://api.openai.com/profile", default)]
     profile: Option<ProfileClaims>,
+    #[serde(rename = "https://gpt.amnezia.org/auth", default)]
+    amnezia_auth: Option<AmneziaAuthClaims>,
     #[serde(rename = "https://api.openai.com/auth", default)]
     auth: Option<AuthClaims>,
 }
@@ -96,6 +98,16 @@ struct AuthClaims {
     chatgpt_account_id: Option<String>,
     #[serde(default)]
     chatgpt_account_is_fedramp: bool,
+}
+
+#[derive(Deserialize)]
+struct AmneziaAuthClaims {
+    #[serde(default)]
+    amnezia_plan_type: Option<PlanType>,
+    #[serde(default)]
+    amnezia_user_id: Option<String>,
+    #[serde(default)]
+    amnezia_account_id: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -139,6 +151,17 @@ pub fn parse_chatgpt_jwt_claims(jwt: &str) -> Result<IdTokenInfo, IdTokenInfoErr
     let email = claims
         .email
         .or_else(|| claims.profile.and_then(|profile| profile.email));
+
+    if let Some(auth) = claims.amnezia_auth {
+        return Ok(IdTokenInfo {
+            email,
+            raw_jwt: jwt.to_string(),
+            chatgpt_plan_type: auth.amnezia_plan_type,
+            chatgpt_user_id: auth.amnezia_user_id,
+            chatgpt_account_id: auth.amnezia_account_id,
+            chatgpt_account_is_fedramp: false,
+        });
+    }
 
     match claims.auth {
         Some(auth) => Ok(IdTokenInfo {

--- a/codex-rs/login/src/token_data_tests.rs
+++ b/codex-rs/login/src/token_data_tests.rs
@@ -30,14 +30,60 @@ fn fake_jwt(payload: serde_json::Value) -> String {
 fn id_token_info_parses_email_and_plan() {
     let fake_jwt = fake_jwt(serde_json::json!({
         "email": "user@example.com",
-        "https://api.openai.com/auth": {
-            "chatgpt_plan_type": "pro"
+        "https://gpt.amnezia.org/auth": {
+            "amnezia_plan_type": "pro",
+            "amnezia_account_id": "account-123",
+            "amnezia_user_id": "user-123"
         }
     }));
 
     let info = parse_chatgpt_jwt_claims(&fake_jwt).expect("should parse");
     assert_eq!(info.email.as_deref(), Some("user@example.com"));
     assert_eq!(info.get_chatgpt_plan_type().as_deref(), Some("Pro"));
+    assert_eq!(info.chatgpt_account_id.as_deref(), Some("account-123"));
+    assert_eq!(info.chatgpt_user_id.as_deref(), Some("user-123"));
+}
+
+#[test]
+fn id_token_info_prefers_amnezia_claims_over_legacy_openai_claims() {
+    let fake_jwt = fake_jwt(serde_json::json!({
+        "email": "user@example.com",
+        "https://gpt.amnezia.org/auth": {
+            "amnezia_plan_type": "business",
+            "amnezia_account_id": "amnezia-account",
+            "amnezia_user_id": "amnezia-user"
+        },
+        "https://api.openai.com/auth": {
+            "chatgpt_plan_type": "free",
+            "chatgpt_account_id": "legacy-account",
+            "chatgpt_user_id": "legacy-user"
+        }
+    }));
+
+    let info = parse_chatgpt_jwt_claims(&fake_jwt).expect("should parse");
+    assert_eq!(
+        info.get_chatgpt_plan_type_raw().as_deref(),
+        Some("business")
+    );
+    assert_eq!(info.chatgpt_account_id.as_deref(), Some("amnezia-account"));
+    assert_eq!(info.chatgpt_user_id.as_deref(), Some("amnezia-user"));
+}
+
+#[test]
+fn id_token_info_keeps_legacy_openai_claims_as_fallback() {
+    let fake_jwt = fake_jwt(serde_json::json!({
+        "email": "user@example.com",
+        "https://api.openai.com/auth": {
+            "chatgpt_plan_type": "pro",
+            "chatgpt_account_id": "legacy-account",
+            "chatgpt_user_id": "legacy-user"
+        }
+    }));
+
+    let info = parse_chatgpt_jwt_claims(&fake_jwt).expect("should parse");
+    assert_eq!(info.get_chatgpt_plan_type_raw().as_deref(), Some("pro"));
+    assert_eq!(info.chatgpt_account_id.as_deref(), Some("legacy-account"));
+    assert_eq!(info.chatgpt_user_id.as_deref(), Some("legacy-user"));
 }
 
 #[test]

--- a/codex-rs/login/tests/suite/device_code_login.rs
+++ b/codex-rs/login/tests/suite/device_code_login.rs
@@ -133,7 +133,7 @@ async fn device_code_login_is_disabled_for_configured_oidc_auth() -> anyhow::Res
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     assert!(
         err.to_string()
-            .contains("Use browser login for configured OIDC auth")
+            .contains("device code login is not enabled for this auth server")
     );
     Ok(())
 }

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -101,6 +101,7 @@ pub(crate) enum SignInOption {
 }
 
 const API_KEY_DISABLED_MESSAGE: &str = "API key login is disabled.";
+const AUTH_PROVIDER_NAME: &str = "Amnezia";
 fn onboarding_request_id() -> codex_app_server_protocol::RequestId {
     codex_app_server_protocol::RequestId::String(Uuid::new_v4().to_string())
 }
@@ -236,6 +237,7 @@ pub(crate) struct AuthModeWidget {
     pub login_status: LoginStatus,
     pub app_server_request_handle: AppServerRequestHandle,
     pub forced_login_method: Option<ForcedLoginMethod>,
+    pub custom_oidc_device_code_enabled: bool,
     pub animations_enabled: bool,
     pub animations_suppressed: Cell<bool>,
 }
@@ -294,9 +296,13 @@ impl AuthModeWidget {
         !matches!(self.forced_login_method, Some(ForcedLoginMethod::Api))
     }
 
+    fn is_device_code_login_allowed(&self) -> bool {
+        self.is_chatgpt_login_allowed() && self.custom_oidc_device_code_enabled
+    }
+
     fn displayed_sign_in_options(&self) -> Vec<SignInOption> {
         let mut options = vec![SignInOption::ChatGpt];
-        if self.is_chatgpt_login_allowed() {
+        if self.is_device_code_login_allowed() {
             options.push(SignInOption::DeviceCode);
         }
         if self.is_api_login_allowed() {
@@ -309,6 +315,8 @@ impl AuthModeWidget {
         let mut options = Vec::new();
         if self.is_chatgpt_login_allowed() {
             options.push(SignInOption::ChatGpt);
+        }
+        if self.is_device_code_login_allowed() {
             options.push(SignInOption::DeviceCode);
         }
         if self.is_api_login_allowed() {
@@ -347,7 +355,7 @@ impl AuthModeWidget {
                 }
             }
             SignInOption::DeviceCode => {
-                if self.is_chatgpt_login_allowed() {
+                if self.is_device_code_login_allowed() {
                     self.start_device_code_login();
                 }
             }
@@ -372,7 +380,10 @@ impl AuthModeWidget {
         let mut lines: Vec<Line> = vec![
             Line::from(vec![
                 "  ".into(),
-                "Sign in with ChatGPT to use Codex as part of your paid plan".into(),
+                format!(
+                    "Sign in with {AUTH_PROVIDER_NAME} to use Amcode as part of your paid plan"
+                )
+                .into(),
             ]),
             Line::from(vec![
                 "  ".into(),
@@ -410,8 +421,8 @@ impl AuthModeWidget {
             vec![line1, line2]
         };
 
-        let chatgpt_description = if !self.is_chatgpt_login_allowed() {
-            "ChatGPT login is disabled"
+        let auth_description = if !self.is_chatgpt_login_allowed() {
+            "Amnezia login is disabled"
         } else {
             "Usage included with Plus, Pro, Business, and Enterprise plans"
         };
@@ -423,8 +434,8 @@ impl AuthModeWidget {
                     lines.extend(create_mode_item(
                         idx,
                         option,
-                        "Sign in with ChatGPT",
-                        chatgpt_description,
+                        &format!("Sign in with {AUTH_PROVIDER_NAME}"),
+                        auth_description,
                     ));
                 }
                 SignInOption::DeviceCode => {
@@ -449,9 +460,11 @@ impl AuthModeWidget {
 
         if !self.is_api_login_allowed() {
             lines.push(
-                "  API key login is disabled by this workspace. Sign in with ChatGPT to continue."
-                    .dim()
-                    .into(),
+                format!(
+                    "  API key login is disabled by this workspace. Sign in with {AUTH_PROVIDER_NAME} to continue."
+                )
+                .dim()
+                .into(),
             );
             lines.push("".into());
         }
@@ -493,12 +506,14 @@ impl AuthModeWidget {
                 state.auth_url.as_str().cyan().underlined(),
             ]));
             lines.push("".into());
-            lines.push(Line::from(vec![
-                "  On a remote or headless machine? Press Esc and choose ".into(),
-                "Sign in with Device Code".cyan(),
-                ".".into(),
-            ]));
-            lines.push("".into());
+            if self.is_device_code_login_allowed() {
+                lines.push(Line::from(vec![
+                    "  On a remote or headless machine? Press Esc and choose ".into(),
+                    "Sign in with Device Code".cyan(),
+                    ".".into(),
+                ]));
+                lines.push("".into());
+            }
             Some(state.auth_url.clone())
         } else {
             None
@@ -518,26 +533,21 @@ impl AuthModeWidget {
 
     fn render_chatgpt_success_message(&self, area: Rect, buf: &mut Buffer) {
         let lines = vec![
-            "✓ Signed in with your ChatGPT account".fg(Color::Green).into(),
+            format!("✓ Signed in with your {AUTH_PROVIDER_NAME} account")
+                .fg(Color::Green)
+                .into(),
             "".into(),
             "  Before you start:".into(),
             "".into(),
-            "  Decide how much autonomy you want to grant Codex".into(),
-            Line::from(vec![
-                "  For more details see the ".into(),
-                "\u{1b}]8;;https://developers.openai.com/codex/security\u{7}Codex docs\u{1b}]8;;\u{7}".underlined(),
-            ])
-            .dim(),
+            "  Decide how much autonomy you want to grant Amcode".into(),
             "".into(),
-            "  Codex can make mistakes".into(),
-            "  Review the code it writes and commands it runs".dim().into(),
+            "  Amcode can make mistakes".into(),
+            "  Review the code it writes and commands it runs"
+                .dim()
+                .into(),
             "".into(),
-            "  Powered by your ChatGPT account".into(),
-            Line::from(vec![
-                "  Uses your plan's rate limits and ".into(),
-                "\u{1b}]8;;https://chatgpt.com/#settings\u{7}training data preferences\u{1b}]8;;\u{7}".underlined(),
-            ])
-            .dim(),
+            format!("  Powered by your {AUTH_PROVIDER_NAME} account").into(),
+            "  Uses your plan's rate limits".dim().into(),
             "".into(),
             "  Press Enter to continue".fg(Color::Cyan).into(),
         ];
@@ -549,7 +559,7 @@ impl AuthModeWidget {
 
     fn render_chatgpt_success(&self, area: Rect, buf: &mut Buffer) {
         let lines = vec![
-            "✓ Signed in with your ChatGPT account"
+            format!("✓ Signed in with your {AUTH_PROVIDER_NAME} account")
                 .fg(Color::Green)
                 .into(),
         ];
@@ -582,7 +592,7 @@ impl AuthModeWidget {
         let mut intro_lines: Vec<Line> = vec![
             Line::from(vec![
                 "> ".into(),
-                "Use your own OpenAI API key for usage-based billing".bold(),
+                "Use your own API key for usage-based billing".bold(),
             ]),
             "".into(),
             "  Paste or type your API key below. It will be stored locally in auth.json.".into(),
@@ -806,10 +816,9 @@ impl AuthModeWidget {
         }
     }
 
-    /// Kicks off the ChatGPT auth flow and keeps the UI state consistent with the attempt.
+    /// Kicks off the managed auth flow and keeps the UI state consistent with the attempt.
     fn start_chatgpt_login(&mut self) {
-        // If we're already authenticated with ChatGPT, don't start a new login –
-        // just proceed to the success message flow.
+        // If we're already authenticated with managed auth, proceed to the success message flow.
         if self.handle_existing_chatgpt_login() {
             return;
         }
@@ -852,6 +861,9 @@ impl AuthModeWidget {
     }
 
     fn start_device_code_login(&mut self) {
+        if !self.is_device_code_login_allowed() {
+            return;
+        }
         if self.handle_existing_chatgpt_login() {
             return;
         }
@@ -1012,6 +1024,7 @@ mod tests {
             login_status: LoginStatus::NotAuthenticated,
             app_server_request_handle: AppServerRequestHandle::InProcess(client.request_handle()),
             forced_login_method: Some(ForcedLoginMethod::Chatgpt),
+            custom_oidc_device_code_enabled: false,
             animations_enabled: true,
             animations_suppressed: std::cell::Cell::new(false),
         };
@@ -1032,6 +1045,36 @@ mod tests {
             &*widget.sign_in_state.read().unwrap(),
             SignInState::PickMode
         ));
+    }
+
+    #[tokio::test]
+    async fn device_code_is_hidden_by_default() {
+        let (mut widget, _tmp) = widget_forced_chatgpt().await;
+        widget.custom_oidc_device_code_enabled = false;
+
+        assert_eq!(
+            widget.displayed_sign_in_options(),
+            vec![SignInOption::ChatGpt]
+        );
+        assert_eq!(
+            widget.selectable_sign_in_options(),
+            vec![SignInOption::ChatGpt]
+        );
+    }
+
+    #[tokio::test]
+    async fn device_code_is_shown_when_enabled() {
+        let (mut widget, _tmp) = widget_forced_chatgpt().await;
+        widget.custom_oidc_device_code_enabled = true;
+
+        assert_eq!(
+            widget.displayed_sign_in_options(),
+            vec![SignInOption::ChatGpt, SignInOption::DeviceCode]
+        );
+        assert_eq!(
+            widget.selectable_sign_in_options(),
+            vec![SignInOption::ChatGpt, SignInOption::DeviceCode]
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -5,6 +5,7 @@ use codex_app_server_client::AppServerEvent;
 use codex_app_server_client::AppServerRequestHandle;
 use codex_app_server_protocol::ServerNotification;
 use codex_exec_server::LOCAL_FS;
+use codex_features::Feature;
 use codex_git_utils::resolve_root_git_project_for_trust;
 #[cfg(target_os = "windows")]
 use codex_protocol::config_types::WindowsSandboxLevel;
@@ -90,6 +91,8 @@ impl OnboardingScreen {
         let cwd = config.cwd.to_path_buf();
         let codex_home = config.codex_home.to_path_buf();
         let forced_login_method = config.forced_login_method;
+        let custom_oidc_device_code_enabled =
+            config.features.enabled(Feature::CustomOidcDeviceCodeAuth);
         let mut steps: Vec<Step> = Vec::new();
         steps.push(Step::Welcome(WelcomeWidget::new(
             !matches!(login_status, LoginStatus::NotAuthenticated),
@@ -110,6 +113,7 @@ impl OnboardingScreen {
                     login_status,
                     app_server_request_handle,
                     forced_login_method,
+                    custom_oidc_device_code_enabled,
                     animations_enabled: config.animations,
                     animations_suppressed: std::cell::Cell::new(false),
                 }));
@@ -459,7 +463,7 @@ pub(crate) async fn run_onboarding_app(
     use tokio_stream::StreamExt;
 
     let mut onboarding_screen = OnboardingScreen::new(tui, args).await;
-    // One-time guard to fully clear the screen after ChatGPT login success message is shown
+    // One-time guard to fully clear the screen after managed login success message is shown.
     let mut did_full_clear_after_success = false;
 
     tui.draw(u16::MAX, |frame| {

--- a/codex-rs/tui/src/onboarding/welcome.rs
+++ b/codex-rs/tui/src/onboarding/welcome.rs
@@ -93,8 +93,8 @@ impl WidgetRef for &WelcomeWidget {
         lines.push(Line::from(vec![
             "  ".into(),
             "Welcome to ".into(),
-            "Codex".bold(),
-            ", OpenAI's command-line coding agent".into(),
+            "Amcode".bold(),
+            ", Amnezia's command-line coding agent".into(),
         ]));
 
         Paragraph::new(lines)

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -574,10 +574,10 @@ impl HistoryCell for StatusHistoryCell {
                 (Some(email), Some(plan)) => format!("{email} ({plan})"),
                 (Some(email), None) => email.clone(),
                 (None, Some(plan)) => plan.clone(),
-                (None, None) => "ChatGPT".to_string(),
+                (None, None) => "Amnezia".to_string(),
             },
             StatusAccountDisplay::ApiKey => {
-                "API key configured (run codex login to use ChatGPT)".to_string()
+                "API key configured (run amcode login to use Amnezia)".to_string()
             }
         });
 
@@ -681,7 +681,7 @@ impl HistoryCell for StatusHistoryCell {
         }
 
         lines.push(Line::from(Vec::<Span<'static>>::new()));
-        // Hide token usage only for ChatGPT subscribers
+        // Hide token usage only for managed-account subscribers.
         if !matches!(self.account, Some(StatusAccountDisplay::ChatGpt { .. })) {
             lines.push(formatter.line("Token usage", self.token_usage_spans()));
         }


### PR DESCRIPTION
## Summary
- rebrand managed auth onboarding/status copy from ChatGPT/OpenAI to Amnezia/Amcode
- hide device-code login unless the custom OIDC device-code feature is enabled
- accept Amnezia ID token account claims under https://gpt.amnezia.org/auth while keeping OpenAI claim fallback

Closes #11

## Testing
- just fmt
- cargo test -p codex-login
- just fix -p codex-login
- cargo build -p codex-cli --bin amcode